### PR TITLE
refactor the main logic of mapreduce

### DIFF
--- a/src/mr/rpc.go
+++ b/src/mr/rpc.go
@@ -5,19 +5,36 @@ import (
 	"os"
 )
 
+const (
+	TaskTypeVoid = iota
+	TaskTypeMap
+	TaskTypeReduce
+)
+
+const (
+	TaskStatusReady = iota
+	TaskStatusDoing
+	TaskStatusDone
+)
+
 type DummyArgs struct{}
 
-type CoordinatorDataReply struct {
-	NReduce  int
-	NumFiles int
+type DummyReply struct{}
+
+type Task struct {
+	Idx    int
+	Type   uint8
+	Status uint8
 }
 
 type TaskReply struct {
-	Filename string
+	Task      *Task
+	Filenames []string
 }
 
-type TestReply struct {
-	Val int
+type ReportArgs struct {
+	Task           *Task
+	InterFilenames []string
 }
 
 // Add your RPC definitions here.


### PR DESCRIPTION
1. Implement the task-assigning logic for the Coordinator
2. Update the mutex logic mechanism of the Coordinator
3. Implement the partial task-reporting logic.
4. Add stages for the whole map-reduce procedure.
5. Update the logic of worker so that workers work according to the task's type assigned to each of them.